### PR TITLE
Add jdk package to `devshell.packages`

### DIFF
--- a/modules/typelevelShell.nix
+++ b/modules/typelevelShell.nix
@@ -54,6 +54,7 @@ in
           '';
 
         devshell.packages = [
+          cfg.jdk.package
           pkgs.nodejs
           pkgs.yarn
         ];


### PR DESCRIPTION
Probably, setting `JAVA_HOME` is already enough, but I was a bit confused as `java --version` did not display the version in the devshell MOTD (as I still have a Java installed globally).